### PR TITLE
Improve performance

### DIFF
--- a/base32.go
+++ b/base32.go
@@ -216,8 +216,7 @@ func (e CorruptInputError) Error() string {
 
 // decode is like Decode but returns an additional 'end' value, which
 // indicates if end-of-message padding was encountered and thus any
-// additional data is an error. This method assumes that src has been
-// stripped of all supported whitespace ('\r' and '\n').
+// additional data is an error.
 func (enc *Encoding) decode(dst, src []byte) (n int, err error) {
 	// Lift the nil check outside of the loop.
 	_ = enc.decodeMap

--- a/base32.go
+++ b/base32.go
@@ -64,8 +64,19 @@ func NewEncoding() *Encoding {
 // Encode encodes src using the encoding enc, writing
 // EncodedLen(len(src)) bytes to dst.
 func (enc *Encoding) Encode(dst, src []byte) {
-	// based on https://github.com/golang/go/blob/ba9e10889976025ee1d027db6b1cad383ec56de8/src/encoding/base32/base32.go#L93
-
+	for len(src) >= 5 {
+		val := uint64(src[0])<<32 | uint64(src[1])<<24 | uint64(src[2])<<16 | uint64(src[3])<<8 | uint64(src[4])
+		dst[0] = enc.encode[(val>>35)&31]
+		dst[1] = enc.encode[(val>>30)&31]
+		dst[2] = enc.encode[(val>>25)&31]
+		dst[3] = enc.encode[(val>>20)&31]
+		dst[4] = enc.encode[(val>>15)&31]
+		dst[5] = enc.encode[(val>>10)&31]
+		dst[6] = enc.encode[(val>>5)&31]
+		dst[7] = enc.encode[(val>>0)&31]
+		src = src[5:]
+		dst = dst[8:]
+	}
 	for len(src) > 0 {
 		var b [8]byte
 


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/shogo82148/go-clockwork-base32
                  │   .old.txt   │              .new.txt               │
                  │    sec/op    │   sec/op     vs base                │
Encode-10            9.026µ ± 1%   4.848µ ± 0%  -46.29% (p=0.000 n=10)
EncodeToString-10   10.659µ ± 2%   6.265µ ± 1%  -41.23% (p=0.000 n=10)
Decode-10           14.937µ ± 0%   8.812µ ± 0%  -41.01% (p=0.000 n=10)
DecodeString-10     15.752µ ± 1%   9.590µ ± 2%  -39.12% (p=0.000 n=10)
geomean              12.27µ        7.118µ       -41.97%

                  │   .old.txt   │               .new.txt                │
                  │     B/s      │      B/s       vs base                │
Encode-10           865.5Mi ± 1%   1611.5Mi ± 0%  +86.19% (p=0.000 n=10)
EncodeToString-10   733.0Mi ± 2%   1247.1Mi ± 1%  +70.13% (p=0.000 n=10)
Decode-10           836.9Mi ± 0%   1418.7Mi ± 0%  +69.52% (p=0.000 n=10)
DecodeString-10     793.6Mi ± 1%   1303.5Mi ± 2%  +64.25% (p=0.000 n=10)
geomean             805.7Mi         1.356Gi       +72.33%

                  │    .old.txt    │               .new.txt                │
                  │      B/op      │     B/op      vs base                 │
Encode-10             0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
EncodeToString-10   26.50Ki ± 0%     26.50Ki ± 0%       ~ (p=1.000 n=10) ¹
Decode-10             0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
DecodeString-10     13.25Ki ± 0%     13.25Ki ± 0%       ~ (p=1.000 n=10) ¹
geomean                          ²                 +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                  │   .old.txt   │              .new.txt               │
                  │  allocs/op   │ allocs/op   vs base                 │
Encode-10           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
EncodeToString-10   2.000 ± 0%     2.000 ± 0%       ~ (p=1.000 n=10) ¹
Decode-10           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
DecodeString-10     1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                        ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```