### PR TITLE
add Go 1.23 to the build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         go:
+          - "stable"
+          - "1.23"
           - "1.22"
           - "1.21"
           - "1.20"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded testing matrix to include additional Go versions (`"stable"` and `"1.23"`), enhancing compatibility and coverage for the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->